### PR TITLE
Fixes admin reservation status bug

### DIFF
--- a/src/components/reservation-page/ReservationForm.tsx
+++ b/src/components/reservation-page/ReservationForm.tsx
@@ -140,7 +140,7 @@ const ReservationForm = ({ item }: ReservationFormProps): JSX.Element => {
         item: item.item,
         checkoutDate: checkoutDate.valueOf(),
         returnDate: returnDate.valueOf(),
-        status: 'Pending'
+        status: values.status
       });
 
       notification.success({


### PR DESCRIPTION
FIxes a bug where reserving an item as an admin always caused the status to be set to `Pending` even when the admin tried to set it to something else.